### PR TITLE
getfile drops exception

### DIFF
--- a/mast/datapower/datapower/DataPower.py
+++ b/mast/datapower/datapower/DataPower.py
@@ -2314,9 +2314,7 @@ class DataPower(object):
                 "file {} from {} domain".format(
                     filename,
                     domain))
-        if not _file:
-            # Empty file node
-            return ""
+            raise
         return base64.decodestring(_file)
 
     @correlate


### PR DESCRIPTION
See old code [here](https://github.com/McIndi/mast.datapower.datapower/blob/20fac8a7a59bd0fb9967f739dc25df378343ac7c/mast/datapower/datapower/DataPower.py#L2306-L2320).

See proposed change [here](https://github.com/McIndi/mast.datapower.datapower/pull/3/files)

Need to re-raise exception in getfile.

@briankearney @mharden108 @steveyeof  Please submit a code review